### PR TITLE
Try to detect tags as well as branches and commits.

### DIFF
--- a/src/adapter.github.js
+++ b/src/adapter.github.js
@@ -7,7 +7,7 @@ const
       'search', 'developer', 'account'
     ]
   , GH_RESERVED_REPO_NAMES = ['followers', 'following', 'repositories']
-  , GH_BRANCH_ICON_SEL  = '.octicon-git-branch'
+  , GH_BRANCH_ICON_SEL  = '.octicon-git-branch, .octicon-tag'
   , GH_404_SEL          = '#parallax_wrapper'
   , GH_PJAX_SEL         = '#js-repo-pjax-container'
   , GH_CONTAINERS       = 'body > .container, .header > .container, .site > .container, .repohead > .container'


### PR DESCRIPTION
Octotree will fallback to rendering the `master` branch's tree when a user is actually viewing/navigating a tag. I am using Octotree v1.6.3 against the latest github.com. 

This happens because the branch/tag dropdown does not contain the icon class `octicon-git-branch` when a tag is selected. Instead it contains the `octicon-tag` icon class. This PR expands the selector to look for either `.octicon-git-branch` or `.octicon-tag`.

With this fix, Octotree will successfully detect and render a tag's tree. 