### PR TITLE
Collapse empty folders by default

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -17,7 +17,7 @@ const
 
   , DEFAULTS = {
     TOKEN    : '',
-    COLLAPSE : false,
+    COLLAPSE : true,
     TABSIZE  : '',
     REMEMBER : false,
     LAZYLOAD : false,


### PR DESCRIPTION
This is a very useful option, especially for java projects and I think it would be a good idea for collapse to be the default behavior. It also matches github behavior when showing folders.

Thanks for the great project!