### PR TITLE
Fix: page is still blank after browser launched

### DIFF
--- a/test/specs.js
+++ b/test/specs.js
@@ -22,6 +22,7 @@ function runTest(browser) {
     before(function (cb) {
       starx(function *() {
         driver = yield factory[browser + 'Driver']
+        yield sleep(5000) // wait for browser starting up
         po = new PageObject(driver, 'https://github.com/buunguyen/octotree')
       })(cb)
     })


### PR DESCRIPTION
Root cause: the driver object from factory is returned (via callback) while the browser app hasn't been ready yet

Solution: wait for 5 seconds