### PR TITLE
add more reserved usernames

### DIFF
--- a/src/adapter.github.js
+++ b/src/adapter.github.js
@@ -4,7 +4,10 @@ const
       'site', 'blog', 'about', 'explore',
       'styleguide', 'showcases', 'trending',
       'stars', 'dashboard', 'notifications',
-      'search', 'developer', 'account'
+      'search', 'developer', 'account',
+      'pulls', 'issues', 'features', 'contact',
+      'security', 'join', 'login', 'watching',
+      'new', 'integrations'
     ]
   , GH_RESERVED_REPO_NAMES = ['followers', 'following', 'repositories']
   , GH_404_SEL = '#parallax_wrapper'


### PR DESCRIPTION
Hi, octotree is a great extension. When I started to work on my own GitHub extension ([GitHub Hovercard](https://github.com/Justineo/github-hovercard)), I learnt quite a lot from your code.

After digging around GitHub website, I found the reserved usernames should include more and sometimes we may ran into some non-reserved tokens that are not usernames (.eg `password_resest`). I used a regex to filter out invalid usernames in my own extension (`/^[a-z0-9]+$|^[a-z0-9](?:[a-z0-9](?!--)|-(?!-))*[a-z0-9]$/i`). Hope this helps.