### PR TITLE
fix branch text too long problem

### DIFF
--- a/src/octotree.less
+++ b/src/octotree.less
@@ -95,6 +95,11 @@
       font-size: 12px;
       margin-top: -6px;
       font-size: 11px;
+      width: 100%;
+      padding-right: 55px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
     .octotree_header_branch:before {
       font-family: octicons;


### PR DESCRIPTION
when broswe the long-name branch, the branch text will wrap to the second line.this request fix this problem.

from 

![image](https://cloud.githubusercontent.com/assets/1589433/10808009/628a466e-7e21-11e5-9d26-6e6be659f870.png)

to

![image](https://cloud.githubusercontent.com/assets/1589433/10808012/69a1ae92-7e21-11e5-9372-fd3a5840c30d.png)
