### PR TITLE
added option to enable/disable downloading of file

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -33,6 +33,7 @@ const
     POPUP    : false,
     SHOWN    : false,
     NONCODE  : false,
+    DOWNLOAD : true
   }
 
   , EVENT = {

--- a/src/constants.js
+++ b/src/constants.js
@@ -13,6 +13,7 @@ const
     POPUP    : 'octotree.popup_shown',
     SHOWN    : 'octotree.sidebar_shown',
     NONCODE  : 'octotree.noncode_shown',
+    DOWNLOAD : 'octotree.download'
   }
 
   , DEFAULTS = {

--- a/src/octotree.js
+++ b/src/octotree.js
@@ -81,6 +81,14 @@ $(document).ready(function() {
             key.unbind(value[0])
             key(value[1], toggleSidebar)
             break
+          case STORE.DOWNLOAD:
+            var $blobIcon = $('.jstree-icon.blob')
+            if (value[1]) {
+              $blobIcon.removeClass('downloading_disabled')
+            } else {
+              $blobIcon.addClass('downloading_disabled')
+            }
+            break
         }
       })
       if (reload) tryLoadRepo(true)

--- a/src/octotree.less
+++ b/src/octotree.less
@@ -115,6 +115,9 @@
       .jstree-icon.blob:before {
         content: '\f00b';
       }
+      .jstree-icon.blob.downloading_disabled:before {
+        content: '\f011';
+      }
     }
     .jstree-icon.commit:before {
       content: '\f017';

--- a/src/template.html
+++ b/src/template.html
@@ -56,6 +56,9 @@
             <label><input type="checkbox" data-store="COLLAPSE"> Collapse folders with single sub-folder</label>
           </div>
           <div>
+            <label><input type="checkbox" data-store="DOWNLOAD"> Enable downloading of files</label>
+          </div>
+          <div>
             <div>
               <label>Hotkeys</label>
               <a href="https://github.com/madrobby/keymaster#defining-shortcuts" target="_blank" tabIndex="-1">supported keys</a>

--- a/src/view.tree.js
+++ b/src/view.tree.js
@@ -1,4 +1,5 @@
 function TreeView($dom, store, adapter) {
+  var self = this;
   this.$view = $dom.find('.octotree_treeview')
   this.store = store
   this.adapter = adapter
@@ -9,6 +10,7 @@ function TreeView($dom, store, adapter) {
     })
     .on('click.jstree', '.jstree-closed>a', function() {
       $.jstree.reference(this).open_node(this)
+      self.toggleDownloadIcon()
     })
     .on('click', function(event) {
       var $target = $(event.target)
@@ -92,17 +94,10 @@ TreeView.prototype.show = function(repo, treeData) {
   treeContainer.one('refresh.jstree', function() {
     self.syncSelection()
     $(self).trigger(EVENT.VIEW_READY)
-    toggleDownloadIcon()
+    self.toggleDownloadIcon()
   })
 
   tree.refresh(true)
-
-  function toggleDownloadIcon() {
-    var enableDownloading = self.store.get(STORE.DOWNLOAD)
-    if (!enableDownloading) {
-      $('.jstree-icon.blob').addClass('downloading_disabled')
-    }
-  }
 
   function sort(folder) {
     folder.sort(function(a, b) {
@@ -127,6 +122,13 @@ TreeView.prototype.show = function(repo, treeData) {
       }
       return item
     })
+  }
+}
+
+TreeView.prototype.toggleDownloadIcon = function () {
+  var enableDownloading = this.store.get(STORE.DOWNLOAD)
+  if (!enableDownloading) {
+    this.$view.find('.jstree-icon.blob').addClass('downloading_disabled')
   }
 }
 

--- a/src/view.tree.js
+++ b/src/view.tree.js
@@ -14,11 +14,16 @@ function TreeView($dom, store, adapter) {
       var $target = $(event.target)
       var self = this
       var download = false
+      var enableDownloading = store.get(STORE.DOWNLOAD)
 
       // handle icon click, fix #122
       if ($target.is('i.jstree-icon')) {
         $target = $target.parent()
-        download = true
+        if (enableDownloading) {
+          download = true
+        } else {
+          download = false
+        }
       }
 
       if (!$target.is('a.jstree-anchor')) return
@@ -87,9 +92,17 @@ TreeView.prototype.show = function(repo, treeData) {
   treeContainer.one('refresh.jstree', function() {
     self.syncSelection()
     $(self).trigger(EVENT.VIEW_READY)
+    toggleDownloadIcon()
   })
 
   tree.refresh(true)
+
+  function toggleDownloadIcon() {
+    var enableDownloading = self.store.get(STORE.DOWNLOAD)
+    if (!enableDownloading) {
+      $('.jstree-icon.blob').addClass('downloading_disabled')
+    }
+  }
 
   function sort(folder) {
     folder.sort(function(a, b) {


### PR DESCRIPTION
I found myself accidentally clicking the "download" icon when trying to navigate to a file. Therefore I created an option to remove this option.

* Added an option to the *Settings* panel labeled "Enable downloading of files"
* Enabling (checking) will allow user to download individual files as normal by clicking the blob icon
* Disabling (unchecking) will prevent user from being able to download individual files by clicking the blob icon

Please let me know if you'd like me to change anything (like the location of different functions I created).