### PR TITLE
Fix finding a wrong branch in pull request page

### DIFF
--- a/src/adapters/github.js
+++ b/src/adapters/github.js
@@ -147,7 +147,8 @@ class GitHub extends Adapter {
     const GH_BRANCH_SEL_1 = '[aria-label="Switch branches or tags"]'
     const GH_BRANCH_SEL_2 = '.repo-root a[data-branch]'
     const GH_BRANCH_SEL_3 = '.repository-sidebar a[aria-label="Code"]'
-    const GH_BRANCH_SEL_4 = 'link[title*="Recent Commits to"]'
+    const GH_BRANCH_SEL_4 = '.current-branch'
+    const GH_BRANCH_SEL_5 = 'link[title*="Recent Commits to"]'
 
     const branch =
       // Detect branch in code page (don't care about non-code pages, let them use the next fallback)
@@ -155,7 +156,12 @@ class GitHub extends Adapter {
       // Non-code page
       ($(GH_BRANCH_SEL_3).attr('href') || ' ').match(/([^\/]+)/g)[3] ||
       // Non-code page (new design)
+      // Specific handle /commit page
       ($(GH_BRANCH_SEL_4).attr('title') || ' ').match(/([^\:]+)/g)[1] ||
+      // Ignore if Github expands one more <link> - use last selected one instead
+      ($(GH_BRANCH_SEL_5).length === 1
+        && ($(GH_BRANCH_SEL_5).attr('title') || ' ').match(/([^\:]+)/g)[1]) ||
+
       // Reuse last selected branch if exist
       (currentRepo.username === username && currentRepo.reponame === reponame && currentRepo.branch)
       // Get default branch from cache


### PR DESCRIPTION
Octotree can't find a correct branch name in pull request page. Ex: https://github.com/defunkt/jquery-pjax/pull/597

I also see that Github expands one more `<link>` into `<head>` when you navigate to several pages. This  is also handled in this commit. 