### PR TITLE
GitLab 7.5.3 b656b85: fix display unfriendly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 tmp
 .idea
+.DS_Store

--- a/src/adapters/gitlab.js
+++ b/src/adapters/gitlab.js
@@ -6,6 +6,8 @@ const GL_RESERVED_REPO_NAMES = []
 const GL_HEADER = '.navbar-gitlab'
 const GL_SIDEBAR = '.sidebar-wrapper'
 const GL_TITLE = 'h1.title'
+const GL_CONTENT = '.container>.content'
+const GL_MAIN_NAV = '.main-nav'
 
 class GitLab extends Adapter {
 
@@ -89,6 +91,8 @@ class GitLab extends Adapter {
       $(GL_HEADER).css('z-index', 3)
       $(GL_SIDEBAR).css('z-index', 1)
       $(GL_TITLE).css('margin-left',  sidebarVisible ? '' : 56)
+      // GL_CONTENT and GL_MAIN_NAV is Special for earlier GitLab such as version 7.5.3 b656b85
+      $(GL_CONTENT).parent().add(GL_MAIN_NAV).css('margin-left', sidebarVisible ? 230 : '')
       $('.octotree_toggle').css({
         right: sidebarVisible ? '' : -102,
         top: sidebarVisible ? '' : 8


### PR DESCRIPTION
* After install from [Chrome Web Store](https://chrome.google.com/webstore/detail/octotree/bkhaagjahfmjljalopjnoealnfndnagc/related), it display unfriendly on GitLab 7.5.3 b656b85
![image](https://cloud.githubusercontent.com/assets/5810063/12001838/673a7fde-ab2c-11e5-9402-46b239460ead.png)

* Fixed it by adjusting margin-left of '.container>.content' and '.main-nav' 
![image](https://cloud.githubusercontent.com/assets/5810063/12001898/ac067306-ab2d-11e5-8005-7fc2eb4c86ec.png)