### PR TITLE
Added a config for optionally path encoding (default true)

### DIFF
--- a/src/adapters/adapter.js
+++ b/src/adapters/adapter.js
@@ -1,5 +1,6 @@
 class Adapter {
-  constructor(deps) {
+  constructor(store, deps) {
+    this.path_encode = store.get(STORE.PATH_ENCODE);
     deps.forEach(dep => window[dep]())
     this._defaultBranch = {}
   }
@@ -73,8 +74,12 @@ class Adapter {
               item.a_attr = { href: '#' }
             }
             else if (type === 'blob') {
+              let path_glue = path;
+              if (this.path_encode) {
+                path_glue = encodeURIComponent(path);
+              }
               item.a_attr = {
-                href: `/${repo.username}/${repo.reponame}/${type}/${repo.branch}/${encodeURIComponent(path)}`
+                href: `/${repo.username}/${repo.reponame}/${type}/${repo.branch}/${path_glue}`
               }
             }
             else if (type === 'commit') {

--- a/src/adapters/github.js
+++ b/src/adapters/github.js
@@ -15,8 +15,8 @@ const GH_CONTAINERS = '.container'
 
 class GitHub extends Adapter {
 
-  constructor() {
-    super(['jquery.pjax.js'])
+  constructor(store) {
+    super(store, ['jquery.pjax.js'])
 
     $.pjax.defaults.timeout = 0 // no timeout
     $(document)

--- a/src/adapters/gitlab.js
+++ b/src/adapters/gitlab.js
@@ -12,7 +12,7 @@ const GL_MAIN_NAV = '.main-nav'
 class GitLab extends Adapter {
 
   constructor(store) {
-    super(['turbolinks.js'])
+    super(store, ['turbolinks.js'])
 
     // GitLab (for now) embeds access token in the page of a logged-in user.
     // Use it to set the token if one isn't available.

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,34 +1,36 @@
 const PREFIX = 'octotree'
 
 const STORE = {
-  TOKEN     : 'octotree.access_token',
-  REMEMBER  : 'octotree.remember',
-  NONCODE   : 'octotree.noncode_shown',
-  HOTKEYS   : 'octotree.hotkeys',
-  LOADALL   : 'octotree.loadall',
-  POPUP     : 'octotree.popup_shown',
-  WIDTH     : 'octotree.sidebar_width',
-  SHOWN     : 'octotree.sidebar_shown',
-  GHEURLS   : 'octotree.gheurls.shared',
-  GLEURLS   : 'octotree.gleurls.shared'
+  TOKEN       : 'octotree.access_token',
+  REMEMBER    : 'octotree.remember',
+  NONCODE     : 'octotree.noncode_shown',
+  HOTKEYS     : 'octotree.hotkeys',
+  LOADALL     : 'octotree.loadall',
+  POPUP       : 'octotree.popup_shown',
+  WIDTH       : 'octotree.sidebar_width',
+  SHOWN       : 'octotree.sidebar_shown',
+  GHEURLS     : 'octotree.gheurls.shared',
+  GLEURLS     : 'octotree.gleurls.shared',
+  PATH_ENCODE : 'octotree.path_encode'
 }
 
 const DEFAULTS = {
-  TOKEN     : '',
-  REMEMBER  : true,
-  NONCODE   : true,
-  LOADALL   : true,
+  TOKEN       : '',
+  REMEMBER    : true,
+  NONCODE     : true,
+  LOADALL     : true,
   // @ifdef SAFARI
-  HOTKEYS   : '⌘+b, ⌃+b',
+  HOTKEYS     : '⌘+b, ⌃+b',
   // @endif
   // @ifndef SAFARI
-  HOTKEYS   : '⌘+⇧+s, ⌃+⇧+s',
+  HOTKEYS     : '⌘+⇧+s, ⌃+⇧+s',
   // @endif
-  POPUP     : false,
-  WIDTH     : 232,
-  SHOWN     : false,
-  GHEURLS   : '',
-  GLEURLS   : ''
+  POPUP       : false,
+  WIDTH       : 232,
+  SHOWN       : false,
+  GHEURLS     : '',
+  GLEURLS     : '',
+  PATH_ENCODE : true
 }
 
 const EVENT = {

--- a/src/template.html
+++ b/src/template.html
@@ -93,6 +93,10 @@
           </div>
 
           <div>
+            <label><input type="checkbox" data-store="PATH_ENCODE"> Encode path in tree</label>
+          </div>
+
+          <div>
             <button type="submit" class="btn">Save</button>
           </div>
         </form>


### PR DESCRIPTION
This implements a config for optional encoding the path component used in the `jsTree` elements.
I've got problems on my private GitLab installation with the encoded paths.

Possible that this could also be cached by changing some http routes or other server settings but I'm not the administrator so this was important for me.

Also works on Github and defaults to `true` to ensure the current behavior.