### PR TITLE
fixed: function getCreateTokenUrl is not defined

### DIFF
--- a/src/adapters/adapter.js
+++ b/src/adapters/adapter.js
@@ -157,7 +157,7 @@ class Adapter {
           message =
             `You are not allowed to access the API.
              You might need to provide an access token.
-             Follow <a href="${getCreateTokenUrl()}" target="_blank">this link</a>
+             Follow <a href="${this.getCreateTokenUrl()}" target="_blank">this link</a>
              to create one and paste it below.`
           needAuth = true
           break


### PR DESCRIPTION
When visiting repos which return `403 Forbidden`, for example: https://github.com/oh-my-fish/oh-my-fish
It shows `getCreateTokenUrl is not defined`

see the screenshot, in the second screenshot, octotree is empty.
![5526a576-1d6f-4e1b-b7b9-cb42494906d4](https://cloud.githubusercontent.com/assets/486382/12929750/1a476c76-cf7d-11e5-802f-fe6191bcaac4.png)
![32f2a99e-98a5-4e29-a055-088d8fc80a8e](https://cloud.githubusercontent.com/assets/486382/12929756/2213f744-cf7d-11e5-9dde-ee667b0124a4.png)