### PR TITLE
fixed: popup overlay not removed when there is error

### DIFF
--- a/src/octotree.js
+++ b/src/octotree.js
@@ -105,6 +105,7 @@ $(document).ready(() => {
       adapter.getRepoFromPath(showInNonCodePage, currRepo, token, (err, repo) => {
         if (err) {
           showError(err)
+          helpPopup.clean()
         }
         else if (repo) {
           $toggler.show()

--- a/src/view.help.js
+++ b/src/view.help.js
@@ -4,6 +4,11 @@ class HelpPopup {
     this.store = store
   }
 
+  clean() {
+    const $view = this.$view
+    $view.remove()
+  }
+
   show() {
     const $view = this.$view
     const store = this.store


### PR DESCRIPTION
This happens when octotree not able to access a repo(HTTP 403) example: https://github.com/oh-my-fish/oh-my-fish. But the 'empty' popup is not removed. which causes the link of `repo owner` and/or link to  the `repo` can not be reached.

See the screenshot below:
![8d7dfe37-d7b7-42f4-9030-b651c91d90ef](https://cloud.githubusercontent.com/assets/486382/12991360/9f438ac2-d117-11e5-913d-f0de30ea9792.png)
