### PR TITLE
Add reserved username

### DIFF
--- a/src/adapters/github.js
+++ b/src/adapters/github.js
@@ -6,7 +6,7 @@ const GH_RESERVED_USER_NAMES = [
   'search', 'developer', 'account',
   'pulls', 'issues', 'features', 'contact',
   'security', 'join', 'login', 'watching',
-  'new', 'integrations'
+  'new', 'integrations', 'gist'
 ]
 const GH_RESERVED_REPO_NAMES = ['followers', 'following', 'repositories']
 const GH_404_SEL = '#parallax_wrapper'


### PR DESCRIPTION
It's used like username on GHE when [domain is http(s)://[hostname]/gist](https://help.github.com/enterprise/2.4/user/articles/creating-gists/#creating-a-gist)