### PR TITLE
Attempt to fix #264

### DIFF
--- a/src/adapters/github.js
+++ b/src/adapters/github.js
@@ -34,12 +34,12 @@ class GitHub extends Adapter {
     // In this case, split-diff page has a wider layout, so need to recompute margin.
     // Note that couldn't do this in response to URL change, since new DOM via pjax might not be ready.
     const diffModeObserver = new window.MutationObserver((mutations) => {
-      for (const mutation of mutations) {
+      mutations.forEach((mutation) => {
         if (~mutation.oldValue.indexOf('split-diff') ||
             ~mutation.target.className.indexOf('split-diff')) {
           return $(document).trigger(EVENT.LAYOUT_CHANGE)
         }
-      }
+      })
     })
 
     diffModeObserver.observe(document.body, {

--- a/src/octotree.js
+++ b/src/octotree.js
@@ -46,7 +46,7 @@ $(document).ready(() => {
     key(store.get(STORE.HOTKEYS), toggleSidebarAndSave)
 
     const views = [treeView, errorView, optsView]
-    for (const view of views) {
+    views.forEach((view) => {
       $(view)
         .on(EVENT.VIEW_READY, function (event) {
           if (this !== optsView) {
@@ -57,7 +57,7 @@ $(document).ready(() => {
         .on(EVENT.VIEW_CLOSE, () => showView(hasError ? errorView.$view : treeView.$view))
         .on(EVENT.OPTS_CHANGE, optionsChanged)
         .on(EVENT.FETCH_ERROR, (event, err) => showError(err))
-    }
+    })
 
     $document
       .on(EVENT.REQ_START, () => $toggler.addClass('octotree_loading'))


### PR DESCRIPTION
Extension is still working in Chrome for me.

I am having issues with running tests locally. Both in my branch and in `master`, I'm seeing the following failure in the `chrome init should toggle upon button click` test case:

```
1) chrome init should toggle upon button click:
     AssertionError: false == true
      at /Users/andrew/Documents/octotree/test/specs.js:58:16
      at next (native)
      at Domain.<anonymous> (/Users/andrew/Documents/octotree/node_modules/starx/lib/index.js:26:56)
      at Domain.run (domain.js:228:14)
      at next (/Users/andrew/Documents/octotree/node_modules/starx/lib/index.js:25:12)
      at /Users/andrew/Documents/octotree/node_modules/starx/lib/index.js:140:10
      at cb (/Users/andrew/Documents/octotree/node_modules/starx/lib/index.js:34:41)
      at /Users/andrew/Documents/octotree/node_modules/starx/lib/index.js:140:10
      at cb (/Users/andrew/Documents/octotree/node_modules/starx/lib/index.js:34:41)
      at /Users/andrew/Documents/octotree/node_modules/starx/lib/index.js:82:14
      at Domain.<anonymous> (/Users/andrew/Documents/octotree/node_modules/starx/lib/index.js:33:40)
      at Domain.run (domain.js:228:14)
      at next (/Users/andrew/Documents/octotree/node_modules/starx/lib/index.js:32:12)
      at /Users/andrew/Documents/octotree/node_modules/starx/lib/index.js:140:10
      at cb (/Users/andrew/Documents/octotree/node_modules/starx/lib/index.js:34:41)
      at /Users/andrew/Documents/octotree/node_modules/starx/lib/index.js:140:10
      at cb (/Users/andrew/Documents/octotree/node_modules/starx/lib/index.js:34:41)
      at /Users/andrew/Documents/octotree/node_modules/starx/lib/index.js:82:14
      at Domain.<anonymous> (/Users/andrew/Documents/octotree/node_modules/starx/lib/index.js:33:40)
      at Domain.run (domain.js:228:14)
      at next (/Users/andrew/Documents/octotree/node_modules/starx/lib/index.js:32:12)
      at /Users/andrew/Documents/octotree/node_modules/starx/lib/index.js:140:10
      at cb (/Users/andrew/Documents/octotree/node_modules/starx/lib/index.js:34:41)
      at /Users/andrew/Documents/octotree/node_modules/starx/lib/index.js:61:11
      at /Users/andrew/Documents/octotree/node_modules/selenium-webdriver/lib/goog/base.js:1582:15
      at webdriver.promise.ControlFlow.runInNewFrame_ (/Users/andrew/Documents/octotree/node_modules/selenium-webdriver/lib/webdriver/promise.js:1654:20)
      at notify (/Users/andrew/Documents/octotree/node_modules/selenium-webdriver/lib/webdriver/promise.js:465:12)
      at notifyAll (/Users/andrew/Documents/octotree/node_modules/selenium-webdriver/lib/webdriver/promise.js:442:7)
      at resolve (/Users/andrew/Documents/octotree/node_modules/selenium-webdriver/lib/webdriver/promise.js:420:7)
      at fulfill (/Users/andrew/Documents/octotree/node_modules/selenium-webdriver/lib/webdriver/promise.js:535:5)
      at Object.webdriver.promise.asap (/Users/andrew/Documents/octotree/node_modules/selenium-webdriver/lib/webdriver/promise.js:776:5)
      at webdriver.promise.ControlFlow.runInNewFrame_ (/Users/andrew/Documents/octotree/node_modules/selenium-webdriver/lib/webdriver/promise.js:1665:25)
      at notify (/Users/andrew/Documents/octotree/node_modules/selenium-webdriver/lib/webdriver/promise.js:465:12)
      at notifyAll (/Users/andrew/Documents/octotree/node_modules/selenium-webdriver/lib/webdriver/promise.js:442:7)
      at resolve (/Users/andrew/Documents/octotree/node_modules/selenium-webdriver/lib/webdriver/promise.js:420:7)
      at fulfill (/Users/andrew/Documents/octotree/node_modules/selenium-webdriver/lib/webdriver/promise.js:535:5)
      at /Users/andrew/Documents/octotree/node_modules/selenium-webdriver/lib/webdriver/promise.js:1520:10
      at /Users/andrew/Documents/octotree/node_modules/selenium-webdriver/lib/goog/base.js:1582:15
      at webdriver.promise.ControlFlow.runInNewFrame_ (/Users/andrew/Documents/octotree/node_modules/selenium-webdriver/lib/webdriver/promise.js:1654:20)
      at notify (/Users/andrew/Documents/octotree/node_modules/selenium-webdriver/lib/webdriver/promise.js:465:12)
      at notifyAll (/Users/andrew/Documents/octotree/node_modules/selenium-webdriver/lib/webdriver/promise.js:442:7)
      at resolve (/Users/andrew/Documents/octotree/node_modules/selenium-webdriver/lib/webdriver/promise.js:420:7)
      at fulfill (/Users/andrew/Documents/octotree/node_modules/selenium-webdriver/lib/webdriver/promise.js:535:5)
      at /Users/andrew/Documents/octotree/node_modules/selenium-webdriver/lib/goog/base.js:1582:15
      at webdriver.promise.ControlFlow.runInNewFrame_ (/Users/andrew/Documents/octotree/node_modules/selenium-webdriver/lib/webdriver/promise.js:1654:20)
      at notify (/Users/andrew/Documents/octotree/node_modules/selenium-webdriver/lib/webdriver/promise.js:465:12)
      at notifyAll (/Users/andrew/Documents/octotree/node_modules/selenium-webdriver/lib/webdriver/promise.js:442:7)
      at resolve (/Users/andrew/Documents/octotree/node_modules/selenium-webdriver/lib/webdriver/promise.js:420:7)
      at fulfill (/Users/andrew/Documents/octotree/node_modules/selenium-webdriver/lib/webdriver/promise.js:535:5)
      at /Users/andrew/Documents/octotree/node_modules/selenium-webdriver/lib/webdriver/promise.js:721:49
      at /Users/andrew/Documents/octotree/node_modules/selenium-webdriver/lib/webdriver/http/http.js:96:5
      at IncomingMessage.<anonymous> (/Users/andrew/Documents/octotree/node_modules/selenium-webdriver/http/index.js:131:7)
      at emitNone (events.js:85:20)
      at IncomingMessage.emit (events.js:179:7)
      at endReadableNT (_stream_readable.js:906:12)
      at nextTickCallbackWith2Args (node.js:475:9)
      at process._tickDomainCallback (node.js:430:17)
  ==== async task ====
  WebElement.getCssValue(right)
      at webdriver.WebDriver.schedule (/Users/andrew/Documents/octotree/node_modules/selenium-webdriver/lib/webdriver/webdriver.js:345:15)
      at webdriver.WebElement.schedule_ (/Users/andrew/Documents/octotree/node_modules/selenium-webdriver/lib/webdriver/webdriver.js:1727:23)
      at webdriver.WebElement.getCssValue (/Users/andrew/Documents/octotree/node_modules/selenium-webdriver/lib/webdriver/webdriver.js:1924:15)
      at WebElementPromiseWrapper.(anonymous function) [as getCssValue] (/Users/andrew/Documents/octotree/test/pageobject.js:163:30)
      at next (native)
      at Domain.<anonymous> (/Users/andrew/Documents/octotree/node_modules/starx/lib/index.js:26:56)
      at Domain.run (domain.js:228:14)
      at next (/Users/andrew/Documents/octotree/node_modules/starx/lib/index.js:25:12)
      at /Users/andrew/Documents/octotree/node_modules/starx/lib/index.js:140:10
      at cb (/Users/andrew/Documents/octotree/node_modules/starx/lib/index.js:34:41)
      at /Users/andrew/Documents/octotree/node_modules/starx/lib/index.js:61:11
      at /Users/andrew/Documents/octotree/node_modules/selenium-webdriver/lib/goog/base.js:1582:15
      at webdriver.promise.ControlFlow.runInNewFrame_ (/Users/andrew/Documents/octotree/node_modules/selenium-webdriver/lib/webdriver/promise.js:1654:20)
      at notify (/Users/andrew/Documents/octotree/node_modules/selenium-webdriver/lib/webdriver/promise.js:465:12)
      at then (/Users/andrew/Documents/octotree/node_modules/selenium-webdriver/lib/webdriver/promise.js:522:7)
      at /Users/andrew/Documents/octotree/node_modules/starx/lib/index.js:60:19
      at Domain.<anonymous> (/Users/andrew/Documents/octotree/node_modules/starx/lib/index.js:33:40)
      at Domain.run (domain.js:228:14)
      at next (/Users/andrew/Documents/octotree/node_modules/starx/lib/index.js:32:12)
      at /Users/andrew/Documents/octotree/node_modules/starx/lib/index.js:140:10
      at cb (/Users/andrew/Documents/octotree/node_modules/starx/lib/index.js:34:41)
      at /Users/andrew/Documents/octotree/node_modules/starx/lib/index.js:61:11
      at /Users/andrew/Documents/octotree/node_modules/selenium-webdriver/lib/goog/base.js:1582:15
      at webdriver.promise.ControlFlow.runInNewFrame_ (/Users/andrew/Documents/octotree/node_modules/selenium-webdriver/lib/webdriver/promise.js:1654:20)
      at notify (/Users/andrew/Documents/octotree/node_modules/selenium-webdriver/lib/webdriver/promise.js:465:12)
      at notifyAll (/Users/andrew/Documents/octotree/node_modules/selenium-webdriver/lib/webdriver/promise.js:442:7)
      at resolve (/Users/andrew/Document
```

I'd be happy to look into the test failures as a separate issue, but I wanted to verify whether or not it was something you're already aware of.