### PR TITLE
Add ChromeDriver as an explicit devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "async": "~0.9.0",
     "babel-core": "^6.1.2",
     "babel-preset-es2015": "^6.1.2",
+    "chromedriver": "^2.21.2",
     "crx": "^0.4.4",
     "event-stream": "*",
     "firefox-profile": "~0.3.6",


### PR DESCRIPTION
Test run after a fresh git clone + npm install fails attempting to run chromedriver.

```
Error: File does not exist: /Users/andrew/Documents/octotree/node_modules/chromedriver/lib/chromedriver/chromedriver
```