### PR TITLE
Enable inline sourcemaps for octotree.js bundle

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -194,9 +194,11 @@ function buildJs(overrides, ctx) {
 
   return pipe(
     src,
+    $.sourcemaps.init(),
     $.babel(),
     $.concat('octotree.js'),
     $.preprocess({context: ctx}),
+    $.sourcemaps.write(),
     './tmp'
   )
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "gulp-replace": "^0.5.4",
     "gulp-run": "^1.6.4",
     "gulp-run-sequence": "*",
+    "gulp-sourcemaps": "^1.6.0",
     "gulp-util": "^2.2.20",
     "gulp-zip": "^2.0.3",
     "jpm": "^1.0.4",


### PR DESCRIPTION
I started working on an adapter for BitBucket, and I added basic sourcemaps support for the main bundle to make debugging easier for myself.

I say basic because it's currently writing the sourcemaps inline, and there is no option to disable it. I think this has some benefits and some drawbacks.

Benefits:
- Easier debugging
- More accurate file/line # when users report issues w/ an exception from the console

Drawbacks:
- File size increase (`octotree.js` went from 56k >> 159k after making the change)

If you don't want to increase the size of the bundle for inline sourcemaps, we can write them externally and not include them in the final browser bundle(s). The only downside there is the loss of more accurate bug reports.

I didn't add sourcemaps for the content scripts (didn't think it would be super helpful). Having said that, let me know if you want me to change anything up.