### PR TITLE
Fix middle click behaviors

### DIFF
--- a/src/adapters/adapter.js
+++ b/src/adapters/adapter.js
@@ -70,7 +70,9 @@ class Adapter {
             if (type === 'tree') {
               if (node) item.children = true
               else folders[item.path] = item.children = []
-              item.a_attr = { href: '#' }
+              item.a_attr = {
+                href: `/${repo.username}/${repo.reponame}/${type}/${repo.branch}/${encodeURIComponent(path)}`
+              }
             }
             else if (type === 'blob') {
               item.a_attr = {

--- a/src/view.tree.js
+++ b/src/view.tree.js
@@ -109,6 +109,9 @@ class TreeView {
 
     if (!$target.is('a.jstree-anchor')) return
 
+    // handle middle click
+    if (event.which === 2) return
+
     // refocus after complete so that keyboard navigation works, fix #158
     const refocusAfterCompletion = () => {
       $(document).one('pjax:success page:load', () => {


### PR DESCRIPTION
Fix middle click behaviors:
- Do not open links in the current tab. Fix #201.
- Directory links can be opened in new tab.