### PR TITLE
fix for showing above github fork overlay

### DIFF
--- a/src/styles/base.less
+++ b/src/styles/base.less
@@ -10,7 +10,7 @@
   left: 0;
   bottom: 0;
   border-right: 1px solid #ddd;
-  z-index: 1000001;
+  z-index: 98; // github fork overlay is 99
   transition: transform .2s ease;
   transform: translate3d(-100%, 0, 0);
 


### PR DESCRIPTION
Fix for this:
![capture](https://cloud.githubusercontent.com/assets/602423/14067063/804b57be-f410-11e5-8fc9-8f6f522f292d.PNG)
