### PR TITLE
Update GitLab access token URL

### DIFF
--- a/src/adapters/gitlab.js
+++ b/src/adapters/gitlab.js
@@ -74,7 +74,7 @@ class GitLab extends Adapter {
 
   // @override
   getCreateTokenUrl() {
-    return `${location.protocol}//${location.host}/profile/account`
+    return `${location.protocol}//${location.host}/profile/personal_access_tokens`
   }
 
   // @override


### PR DESCRIPTION
It looks like this now:
https://gitlab.com/profile/personal_access_tokens