### PR TITLE
Skip when a url ends with `.patch`, `.diff`

### DIFF
--- a/src/adapters/github.js
+++ b/src/adapters/github.js
@@ -123,9 +123,9 @@ class GitHub extends Adapter {
       return cb()
     }
 
-    // (username)/(reponame)[/(type)]
-    const match = window.location.pathname.match(/([^\/]+)\/([^\/]+)(?:\/([^\/]+))?/)
-    if (!match) {
+    // (username)/(reponame)[/(type)][.*][.(patch|diff)]
+    const match = window.location.pathname.match(/([^\/]+)\/([^\/]+)(?:\/([^\/]+))?(?:\/[^.]+)?(?:\.(patch|diff))?$/i)
+    if (!match || match[4]) {
       return cb()
     }
 


### PR DESCRIPTION
Fix #307 