### PR TITLE
Add a missing OR operator

### DIFF
--- a/src/adapters/github.js
+++ b/src/adapters/github.js
@@ -169,7 +169,7 @@ class GitHub extends Adapter {
       ($(GH_BRANCH_SEL_5).length === 1 && ($(GH_BRANCH_SEL_5).attr('title') || ' ').match(/([^\:]+)/g)[1]) ||
 
       // Reuse last selected branch if exist
-      (currentRepo.username === username && currentRepo.reponame === reponame && currentRepo.branch)
+      (currentRepo.username === username && currentRepo.reponame === reponame && currentRepo.branch) ||
       // Get default branch from cache
       this._defaultBranch[username + '/' + reponame]
 


### PR DESCRIPTION
Add a missing `||` operator which was deleted in https://github.com/buunguyen/octotree/commit/b349180b9099516932991eb60c86040a76f9dfa4?diff=unified#diff-7442ec7ebd4a6a56cbd510da52266f95R154