### PR TITLE
[WIP] Add support for Bitbucket Cloud

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -170,6 +170,7 @@ function buildJs(overrides, ctx) {
     './tmp/template.js',
     './src/constants.js',
     './src/adapters/adapter.js',
+    './src/adapters/bitbucket.js',
     './src/adapters/github.js',
     './src/adapters/gitlab.js',
     './src/view.help.js',

--- a/src/adapters/adapter.js
+++ b/src/adapters/adapter.js
@@ -76,7 +76,7 @@ class Adapter {
               // encodes but retains the slashes, see #274
               const encodedPath = path.split('/').map(encodeURIComponent).join('/')
               item.a_attr = {
-                href: `/${repo.username}/${repo.reponame}/${type}/${repo.branch}/${encodedPath}`
+                href: this.getItemHref(repo, type, path)
               }
             }
             else if (type === 'commit') {
@@ -287,4 +287,12 @@ class Adapter {
   _getSubmodules(tree, opts, cb) {
     throw new Error('Not implemented')
   }
+
+  /**
+   * Returns item's href value.
+   * @api public
+   */
+   getItemHref(repo, type, encodedPath) {
+     return `/${repo.username}/${repo.reponame}/${type}/${repo.branch}/${encodedPath}`
+   }
 }

--- a/src/adapters/bitbucket.js
+++ b/src/adapters/bitbucket.js
@@ -1,3 +1,9 @@
+const BB_RESERVED_USER_NAMES = [
+  'account', 'dashboard', 'integrations', 'product',
+  'repo', 'snippets', 'support', 'whats-new'
+]
+const BB_RESERVED_REPO_NAMES = []
+
 class Bitbucket extends Adapter {
 
   constructor() {
@@ -45,6 +51,12 @@ class Bitbucket extends Adapter {
 
     const username = match[1]
     const reponame = match[2]
+
+    // Not a repository, skip
+    if (~BB_RESERVED_USER_NAMES.indexOf(username) ||
+        ~BB_RESERVED_REPO_NAMES.indexOf(reponame)) {
+      return cb()
+    }
 
     // TODO: get branch name
     const branch = ''

--- a/src/adapters/bitbucket.js
+++ b/src/adapters/bitbucket.js
@@ -3,6 +3,7 @@ const BB_RESERVED_USER_NAMES = [
   'repo', 'snippets', 'support', 'whats-new'
 ]
 const BB_RESERVED_REPO_NAMES = []
+const BB_RESERVED_TYPES = ['raw']
 const BB_404_SEL = '#error.404'
 const BB_PJAX_CONTAINER_SEL = '#source-container'
 
@@ -95,17 +96,19 @@ class Bitbucket extends Adapter {
 
     const username = match[1]
     const reponame = match[2]
+    const type = match[3]
 
     // Not a repository, skip
     if (~BB_RESERVED_USER_NAMES.indexOf(username) ||
-        ~BB_RESERVED_REPO_NAMES.indexOf(reponame)) {
+        ~BB_RESERVED_REPO_NAMES.indexOf(reponame) ||
+        ~BB_RESERVED_TYPES.indexOf(type)) {
       return cb()
     }
 
     // Skip non-code page unless showInNonCodePage is true
     // with Bitbucket /username/repo is non-code page
     if (!showInNonCodePage &&
-      (!match[3] || (match[3] && match[3] !== 'src'))) {
+      (!type || (tyep && type !== 'src'))) {
       return cb()
     }
 

--- a/src/adapters/bitbucket.js
+++ b/src/adapters/bitbucket.js
@@ -3,6 +3,7 @@ const BB_RESERVED_USER_NAMES = [
   'repo', 'snippets', 'support', 'whats-new'
 ]
 const BB_RESERVED_REPO_NAMES = []
+const BB_404_SEL = '#error.404'
 const BB_PJAX_CONTAINER_SEL = '#source-container'
 
 class Bitbucket extends Adapter {
@@ -41,8 +42,10 @@ class Bitbucket extends Adapter {
   // @override
   getRepoFromPath(showInNonCodePage, currentRepo, token, cb) {
 
-    // TODO: skip 404 page
-
+    // 404 page, skip
+    if ($(BB_404_SEL).length) {
+      return cb()
+    }
 
     // (username)/(reponame)[/(type)]
     const match = window.location.pathname.match(/([^\/]+)\/([^\/]+)(?:\/([^\/]+))?/)

--- a/src/adapters/bitbucket.js
+++ b/src/adapters/bitbucket.js
@@ -156,6 +156,14 @@ class Bitbucket extends Adapter {
   }
 
   // @override
+  downloadFile(path, fileName) {
+    const link = document.createElement('a')
+    link.setAttribute('href', path.replace(/\/src\//, '/raw/'))
+    link.setAttribute('download', fileName)
+    link.click()
+  }
+
+  // @override
   loadCodeTree(opts, cb) {
     opts.path = opts.node.path
     this._loadCodeTree(opts, (item) => {

--- a/src/adapters/bitbucket.js
+++ b/src/adapters/bitbucket.js
@@ -199,13 +199,13 @@ class Bitbucket extends Adapter {
 
   _getSubmodulesInCurrentPath(tree, opts, cb) {
     const currentPath = opts.path
-    const filterFn = (currentPath) ?
-      ((path) => path.startsWith(`${currentPath}/`)) :
-      ((path) => path.indexOf('/') === -1)
+    const isInCurrentPath = currentPath
+      ? (path) => path.startsWith(`${currentPath}/`)
+      : (path) => path.indexOf('/') === -1
 
     const submodules = opts.repo.submodules
     const submodulesInCurrentPath = {}
-    Object.keys(submodules).filter(filterFn).forEach((key) => {
+    Object.keys(submodules).filter(isInCurrentPath).forEach((key) => {
       submodulesInCurrentPath[key] = submodules[key]
     })
 

--- a/src/adapters/bitbucket.js
+++ b/src/adapters/bitbucket.js
@@ -19,7 +19,7 @@ class Bitbucket extends Adapter {
 
   // @override
   getCssClass() {
-    return 'octotree_github_sidebar'
+    return 'octotree_bitbucket_sidebar'
   }
 
   // @override

--- a/src/adapters/bitbucket.js
+++ b/src/adapters/bitbucket.js
@@ -77,6 +77,8 @@ class Bitbucket extends Adapter {
 
   // @override
   updateLayout(togglerVisible, sidebarVisible, sidebarWidth) {
+    $('.octotree_toggle').css('right', sidebarVisible ? '' : -44)
+    $('.aui-header').css('padding-left', sidebarVisible ? '' : 56)
     $('html').css('margin-left', sidebarVisible ? sidebarWidth : '')
   }
 

--- a/src/adapters/bitbucket.js
+++ b/src/adapters/bitbucket.js
@@ -1,0 +1,115 @@
+class Bitbucket extends Adapter {
+
+  constructor() {
+    super([])
+  }
+
+  // @override
+  init($sidebar) {
+    super.init($sidebar)
+
+    // TODO
+  }
+
+  // @override
+  getCssClass() {
+    return 'octotree_github_sidebar'
+  }
+
+  // @override
+  canLoadEntireTree() {
+    return true
+  }
+
+  // @override
+  getCreateTokenUrl() {
+    return `${location.protocol}//${location.host}/account/admin/app-passwords/new`
+  }
+
+  // @override
+  updateLayout(togglerVisible, sidebarVisible, sidebarWidth) {
+    // TODO
+    console.log('updateLayout')
+  }
+
+  // @override
+  getRepoFromPath(showInNonCodePage, currentRepo, token, cb) {
+
+    // TODO: skip 404 page
+
+
+    // (username)/(reponame)[/(type)]
+    const match = window.location.pathname.match(/([^\/]+)\/([^\/]+)(?:\/([^\/]+))?/)
+    if (!match) {
+      return cb()
+    }
+
+    const username = match[1]
+    const reponame = match[2]
+
+    // TODO: get branch name
+    const branch = ''
+
+    const repo = {username: username, reponame: reponame, branch: branch}
+
+    if (repo.branch) {
+      cb(null, repo)
+    }
+    else {
+      this._get('/main-branch', {repo, token}, (err, data) => {
+        if (err) return cb(err)
+        repo.branch = this._defaultBranch[username + '/' + reponame] = data.name || 'master'
+        cb(null, repo)
+      })
+    }
+  }
+
+  // @override
+  selectFile(path) {
+    // TODO
+    console.log('selectFile')
+  }
+
+  // @override
+  loadCodeTree(opts, cb) {
+    opts.path = ''
+    this._loadCodeTree(opts, (item) => {
+      if (item.path.endsWith('/')) {
+        item.path = item.path.slice(0, -1)
+        item.type = 'tree'
+      } else {
+        item.type = 'blob'
+      }
+    }, cb)
+  }
+
+  // @override
+  _getTree(path, opts, cb) {
+    // `/directory` endpoint is not officially supported.
+    // See https://bitbucket.org/site/master/issues/8316/rest-api-list-all-files-in-repo-like-git
+    this._get(`/directory/${opts.repo.branch}/`, opts, (err, res) => {
+      if (err) cb(err)
+      else cb(null, res.values.filter(v => v !== '/').map(v => ({ path: v })))
+    })
+  }
+
+  // @override
+  _getSubmodules(tree, opts, cb) {
+    const item = tree.filter((item) => /^\.gitmodules$/i.test(item.path))[0]
+    if (!item) return cb()
+
+    // TODO: get submodules
+    cb()
+  }
+
+  _get(path, opts, cb) {
+    const host = location.protocol + '//' + 'api.bitbucket.org/1.0'
+    const url = `${host}/repositories/${opts.repo.username}/${opts.repo.reponame}${path || ''}`
+    const cfg  = { url, method: 'GET', cache: false }
+
+    // TODO: handle too many files failure
+    $.ajax(cfg)
+      .done((data) => cb(null, data))
+      .fail((jqXHR) => this._handleError(jqXHR, cb))
+  }
+}

--- a/src/adapters/bitbucket.js
+++ b/src/adapters/bitbucket.js
@@ -28,8 +28,7 @@ class Bitbucket extends Adapter {
 
   // @override
   updateLayout(togglerVisible, sidebarVisible, sidebarWidth) {
-    // TODO
-    console.log('updateLayout')
+    $('html').css('margin-left', sidebarVisible ? sidebarWidth : '')
   }
 
   // @override

--- a/src/adapters/bitbucket.js
+++ b/src/adapters/bitbucket.js
@@ -65,8 +65,16 @@ class Bitbucket extends Adapter {
       return cb()
     }
 
-    // TODO: get branch name
-    const branch = ''
+    // Get branch by inspecting page, quite fragile so provide multiple fallbacks
+    const BB_BRANCH_SEL_1 = '.branch-dialog-trigger'
+
+    const branch =
+      // Code page
+      $(BB_BRANCH_SEL_1).attr('title') ||
+      // Assume same with previously
+      (currentRepo.username === username && currentRepo.reponame === reponame && currentRepo.branch) ||
+      // Default from cache
+      this._defaultBranch[username + '/' + reponame]
 
     const repo = {username: username, reponame: reponame, branch: branch}
 

--- a/src/adapters/bitbucket.js
+++ b/src/adapters/bitbucket.js
@@ -189,6 +189,15 @@ class Bitbucket extends Adapter {
     const url = `${host}/repositories/${opts.repo.username}/${opts.repo.reponame}${path || ''}`
     const cfg  = { url, method: 'GET', cache: false }
 
+    if (opts.token) {
+      // Bitbucket App passwords can be used only for Basic Authentication.
+      // Get username of logged-in user.
+      const currentUser = JSON.parse($('body').attr('data-current-user'))
+      if (currentUser.username) {
+        cfg.headers = { Authorization: 'Basic ' + btoa(currentUser.username + ':' + opts.token) }
+      }
+    }
+
     $.ajax(cfg)
       .done((data) => cb(null, data))
       .fail((jqXHR) => this._handleError(jqXHR, cb))

--- a/src/adapters/bitbucket.js
+++ b/src/adapters/bitbucket.js
@@ -58,6 +58,13 @@ class Bitbucket extends Adapter {
       return cb()
     }
 
+    // Skip non-code page unless showInNonCodePage is true
+    // with Bitbucket /username/repo is non-code page
+    if (!showInNonCodePage &&
+      (!match[3] || (match[3] && match[3] !== 'src'))) {
+      return cb()
+    }
+
     // TODO: get branch name
     const branch = ''
 

--- a/src/adapters/bitbucket.less
+++ b/src/adapters/bitbucket.less
@@ -5,6 +5,7 @@
 
   .octotree_bitbucket_sidebar {
     a.octotree_toggle {
+      top: 9px;
       right: 5px;
       &:not(.octotree_loading) > span:after {
         content: data-uri('image/svg+xml;charset=UTF-8', './octicons/chevron-left.svg');
@@ -122,8 +123,8 @@
   }
 
   a.octotree_toggle {
-    top: 9px;
-    right: -35px;
+    top: 5px;
+    right: -44px;
 
     &:not(.octotree_loading) > span:after {
       content: data-uri('image/svg+xml;charset=UTF-8', './octicons/chevron-right.svg');

--- a/src/adapters/bitbucket.less
+++ b/src/adapters/bitbucket.less
@@ -1,0 +1,135 @@
+.octotree-show {
+  .octotree_bitbucket_only {
+    display: none;
+  }
+
+  .octotree_bitbucket_sidebar {
+    a.octotree_toggle {
+      right: 5px;
+      &:not(.octotree_loading) > span:after {
+        content: data-uri('image/svg+xml;charset=UTF-8', './octicons/chevron-left.svg');
+      }
+      &:not(.octotree_loading):hover > span:after {
+        content: data-uri('image/svg+xml;charset=UTF-8', './octicons/chevron-left-hover.svg');
+      }
+    }
+  }
+
+  body.split-diff .container {
+    padding-left: 0;
+  }
+}
+
+.octotree_bitbucket_sidebar {
+  padding-top: 49px;
+  background-color: #f5f5f5;
+
+  .octotree_bitbucket_only {
+    display: block;
+  }
+
+  .octotree_views {
+    .octotree_view {
+      .octotree_view_header {
+        height: 49px;
+        background-color: #f3f3f3;
+        background-image: linear-gradient(#f9f9f9, #f3f3f3);
+        background-repeat: repeat-x;
+        border-bottom: 1px solid #e5e5e5;
+      }
+
+      .octotree_help {
+        & > span:before {
+          content: data-uri('image/svg+xml;charset=UTF-8', './octicons/question.svg');
+        }
+      }
+    }
+
+    .octotree_treeview {
+      .octotree_header_repo {
+        font-size: 13px;
+      }
+      .octotree_header_repo:before {
+        font-family: 'Atlassian Icons';
+        content: '\f135';
+        color: #707070;
+      }
+      .octotree_header_branch {
+        font-size: 11px;
+      }
+      .octotree_header_branch:before {
+        font-family: 'Atlassian Icons';
+        content: '\f127';
+        color: #707070;
+      }
+      .jstree-icon.tree:before {
+        content: '\f131';
+        color: #707070;
+      }
+      .jstree-icon.blob:before {
+        content: '\f12e';
+        color: #707070;
+      }
+      .jstree-node.jstree-leaf:hover {
+        .jstree-icon.blob {
+          margin-top: 3px;
+        }
+        .jstree-icon.blob:before {
+          content: data-uri('image/svg+xml;charset=UTF-8', './octicons/cloud-download.svg');
+        }
+      }
+      .jstree-icon.commit:before {
+        content: '\f139';
+        color: #707070;
+      }
+      .jstree-anchor {
+        color: #3572b0 !important;
+        & > span {
+          color: black;
+        }
+      }
+      .jstree-default {
+        .jstree-wholerow-hovered {
+          background: #e6e6e6;
+        }
+        .jstree-wholerow-clicked {
+          background: #e6e6e6;
+        }
+      }
+      .jstree-icon.tree, .jstree-icon.blob, .jstree-icon.commit {
+        font: normal normal 16px 'Atlassian Icons';
+      }
+    }
+  }
+
+  a.octotree_toggle, a.octotree_opts {
+    color: black !important;
+
+    &:hover, &.selected {
+      color: #4183C4 !important;
+    }
+  }
+
+  a.octotree_opts {
+    top: 16px;
+    right: 38px;
+    width: 14px;
+    height: 16px;
+    background: data-uri('image/svg+xml;charset=UTF-8', './octicons/gear.svg');
+    &:hover {
+      background: data-uri('image/svg+xml;charset=UTF-8', './octicons/gear-hover.svg');
+    }
+  }
+
+  a.octotree_toggle {
+    top: 9px;
+    right: -35px;
+
+    &:not(.octotree_loading) > span:after {
+      content: data-uri('image/svg+xml;charset=UTF-8', './octicons/chevron-right.svg');
+    }
+    &:not(.octotree_loading):hover > span:after {
+      content: data-uri('image/svg+xml;charset=UTF-8', './octicons/chevron-right-hover.svg');
+    }
+  }
+}

--- a/src/config/chrome/manifest.json
+++ b/src/config/chrome/manifest.json
@@ -9,6 +9,7 @@
     "128": "icons/icon128.png"
   },
   "permissions": [
+    "https://bitbucket.org/*",
     "https://github.com/*",
     "https://gitlab.com/*",
     "storage"

--- a/src/config/firefox/firefox.js
+++ b/src/config/firefox/firefox.js
@@ -2,7 +2,7 @@ const data = require('sdk/self').data
 const pageMod = require('sdk/page-mod')
 
 pageMod.PageMod({
-  include: ['https://github.com/*', 'https://gitlab.com/*'],
+  include: ['https://bitbucket.org/*', 'https://github.com/*', 'https://gitlab.com/*'],
   contentScriptFile : [data.url('jquery.js'),
                        data.url('jquery-ui.js'),
                        data.url('jstree.js'),

--- a/src/config/firefox/package.json
+++ b/src/config/firefox/package.json
@@ -11,7 +11,13 @@
   "license": "MIT",
   "version": "2.0.17",
   "permissions": {
-    "cross-domain-content": ["https://api.github.com", "https://github.com", "https://gitlab.com"],
+    "cross-domain-content": [
+      "https://api.bitbucket.org",
+      "https://api.github.com",
+      "https://bitbucket.org",
+      "https://github.com",
+      "https://gitlab.com"
+    ],
     "private-browsing": true
   }
 }

--- a/src/config/safari/Info.plist
+++ b/src/config/safari/Info.plist
@@ -39,6 +39,7 @@
 			</array>
 			<key>Whitelist</key>
 			<array>
+				<string>https://bitbucket.org/*</string>
 				<string>https://github.com/*</string>
 				<string>https://gitlab.com/*</string>
 			</array>

--- a/src/config/safari/Info.plist
+++ b/src/config/safari/Info.plist
@@ -54,6 +54,7 @@
 			<dict>
 				<key>Allowed Domains</key>
 				<array>
+					<string>bitbucket.org</string>
 					<string>github.com</string>
 					<string>gitlab.com</string>
 				</array>

--- a/src/octotree.js
+++ b/src/octotree.js
@@ -129,7 +129,8 @@ $(document).ready(() => {
           }
 
           if (isSidebarVisible()) {
-            const repoChanged = JSON.stringify(repo) !== JSON.stringify(currRepo)
+            const replacer = ['username', 'reponame', 'branch']
+            const repoChanged = JSON.stringify(repo, replacer) !== JSON.stringify(currRepo, replacer)
 
             if (repoChanged || reload === true) {
               $document.trigger(EVENT.REQ_START)

--- a/src/octotree.js
+++ b/src/octotree.js
@@ -15,6 +15,11 @@ $(document).ready(() => {
       .map((url) => url.replace(/(.*?:\/\/[^/]+)(.*)/, '$1'))
       .concat('https://github.com')
 
+    // TODO
+    if (location.host === 'bitbucket.org') {
+      return new Bitbucket(store)
+    }
+
     return ~githubUrls.indexOf(`${location.protocol}//${location.host}`)
       ? new GitHub(store)
       : new GitLab(store)

--- a/src/octotree.js
+++ b/src/octotree.js
@@ -11,18 +11,26 @@ $(document).ready(() => {
   }
 
   function createAdapter() {
+    const normailzeUrl = (url) => url.replace(/(.*?:\/\/[^/]+)(.*)/, '$1')
+
     const githubUrls = store.get(STORE.GHEURLS).split(/\n/)
-      .map((url) => url.replace(/(.*?:\/\/[^/]+)(.*)/, '$1'))
+      .map(normailzeUrl)
       .concat('https://github.com')
 
-    // TODO
-    if (location.host === 'bitbucket.org') {
+    const gitlabUrls = store.get(STORE.GLEURLS).split(/\n/)
+      .map(normailzeUrl)
+      .concat('https://gitlab.com')
+
+    const bitbucketUrls = ['https://bitbucket.org']
+    const currentUrl = `${location.protocol}//${location.host}`
+
+    if (~githubUrls.indexOf(currentUrl)) {
+      return new GitHub(store)
+    } else if (~gitlabUrls.indexOf(currentUrl)) {
+      return new GitLab(store)
+    } else if (~bitbucketUrls.indexOf(currentUrl)) {
       return new Bitbucket(store)
     }
-
-    return ~githubUrls.indexOf(`${location.protocol}//${location.host}`)
-      ? new GitHub(store)
-      : new GitLab(store)
   }
 
   function loadExtension() {

--- a/src/styles/octotree.less
+++ b/src/styles/octotree.less
@@ -1,3 +1,4 @@
 @import "base";
+@import "../adapters/bitbucket";
 @import "../adapters/github";
 @import "../adapters/gitlab";

--- a/src/template.html
+++ b/src/template.html
@@ -1,6 +1,6 @@
 <div>
   <nav class="octotree_sidebar">
-    <a class="octotree_toggle btn">
+    <a class="octotree_toggle btn aui-button">
       <div class="loader"></div>
       <span></span>
 
@@ -32,7 +32,7 @@
             <input name="token" type="text" placeholder="Paste access token here" autocomplete="off">
           </div>
           <div>
-            <button type="submit" class="btn">Save</button>
+            <button type="submit" class="btn aui-button">Save</button>
             <a href="https://github.com/buunguyen/octotree#access-token" target="_blank" tabIndex="-1">Why is this required?</a>
           </div>
           <div class="error"></div>
@@ -88,7 +88,7 @@
           </div>
 
           <div>
-            <button type="submit" class="btn">Save</button>
+            <button type="submit" class="btn aui-button">Save</button>
           </div>
         </form>
       </div>

--- a/src/view.options.js
+++ b/src/view.options.js
@@ -49,18 +49,20 @@ class OptionsView {
      */
     // @ifdef CHROME
     const $ta = this.$view.find('[data-store$=EURLS]').filter(':visible')
-    const storeKey = $ta.data('store')
-    const urls = $ta.val().split(/\n/).filter((url) => url !== '')
+    if ($ta.length > 0) {
+      const storeKey = $ta.data('store')
+      const urls = $ta.val().split(/\n/).filter((url) => url !== '')
 
-    if (urls.length > 0) {
-      chrome.runtime.sendMessage({type: 'requestPermissions', urls: urls}, (granted) => {
-        if (!granted) {
-          // permissions not granted (by user or error), reset value
-          $ta.val(this.store.get(STORE[storeKey]))
-        }
-        this._saveOptions()
-      })
-      return
+      if (urls.length > 0) {
+        chrome.runtime.sendMessage({type: 'requestPermissions', urls: urls}, (granted) => {
+          if (!granted) {
+            // permissions not granted (by user or error), reset value
+            $ta.val(this.store.get(STORE[storeKey]))
+          }
+          this._saveOptions()
+        })
+        return
+      }
     }
     // @endif
 


### PR DESCRIPTION
Add support for Bitbucket Cloud. Refs #22.
I confirmed that this works well on Chrome, Safari, and Firefox.

For now, this doesn't support for Bitbucket Server and may not work well for Bitbucket Cloud with Mercurial. (I'm sorry but I don't use Bitbucket Server and Mercurial.)

I have two concerns about implementation.

Firstly, there are [app passwords](https://blog.bitbucket.org/2016/06/06/app-passwords-bitbucket-cloud/) on Bitbucket, which are about the same functions as personal access tokens on GitHub, but app passwords can be used only for Basic Authentication. So the username is also required to access private repositories. Get the username embedded in HTML when the user is logged in, and use it for HTTP requests.

Secondly, git submodules can't be retrieved with Bitbucket API [src Resources](https://confluence.atlassian.com/bitbucket/src-resources-296095214.html) but can only by reading `.gitmodules` content. So when reading `.gitmodules` content for the first time, memoize it so that submodules will be inserted into the tree later.

And I have a question about CSS on Safari. Injected styles don't override Bitbucket original styles and the layout is skewed.

If there are something to be fixed, please point out them.
