### PR TITLE
Fix #356

### DIFF
--- a/src/config/firefox/package.json
+++ b/src/config/firefox/package.json
@@ -16,6 +16,7 @@
       "https://github.com",
       "https://gitlab.com"
     ],
-    "private-browsing": true
+    "private-browsing": true,
+    "multiprocess": true
   }
 }


### PR DESCRIPTION
Add `multiprocess` flag to Firefox's `package.json`.

Fix #356.

```diff
      "https://github.com",
      "https://gitlab.com"
    ],
-    "private-browsing": true
+    "private-browsing": true,
+    "multiprocess": true
  }
}
```