### PR TITLE
Update for redesign

### DIFF
--- a/src/adapters/github.less
+++ b/src/adapters/github.less
@@ -117,7 +117,7 @@
   }
 
   a.octotree_toggle {
-    top: 9px;
+    top: 12px;
     right: -35px;
 
     &:not(.octotree_loading) > span:after {

--- a/src/adapters/github.less
+++ b/src/adapters/github.less
@@ -21,7 +21,7 @@
 }
 
 .octotree_github_sidebar {
-  padding-top: 49px;
+  padding-top: 54px;
   background-color: #f7f7f7;
 
   .octotree_github_only {
@@ -31,8 +31,8 @@
   .octotree_views {
     .octotree_view {
       .octotree_view_header {
-        height: 49px;
-        background-color: #f3f3f3;
+        height: 54px;
+        background-color: #1e2327;
         background-image: linear-gradient(#f9f9f9, #f3f3f3);
         background-repeat: repeat-x;
         border-bottom: 1px solid #e5e5e5;
@@ -55,6 +55,7 @@
         content: data-uri('image/svg+xml;charset=UTF-8', './octicons/repo.svg');
       }
       .octotree_header_branch {
+        color: #fff;
         font-size: 11px;
       }
       .octotree_header_branch:before {
@@ -96,11 +97,11 @@
     }
   }
 
-  a.octotree_toggle, a.octotree_opts {
-    color: black !important;
+  a.octotree_toggle, a.octotree_opts, a.octotree_header_repo {
+    color: rgba(255, 255, 255, 0.75) !important;
 
     &:hover, &.selected {
-      color: #4183C4 !important;
+      color: rgba(255, 255, 255, 1) !important;
     }
   }
 


### PR DESCRIPTION
### Description
Github recently redesigned the header on the site and the toggle/navbar_header no longer match.
You can see in these screenshots that the new header is is slightly taller and has a dark theme.

<img width="484" alt="screen shot 2017-02-12 at 11 25 37 am" src="https://cloud.githubusercontent.com/assets/11323991/22865317/4b18e1de-f116-11e6-8160-2f7d219463a1.png">

<img width="598" alt="screen shot 2017-02-12 at 11 25 55 am" src="https://cloud.githubusercontent.com/assets/11323991/22865319/4e553ac8-f116-11e6-8ae5-de83f14a8281.png">

### Proposal
I suggest that the octotree header be updated to match the height and color of the new header. Also that the `toggle` and `toggle:hover` colors match the links on the new header.

I have made what I believe to be the necessary code changes to implement this update. 

However, I have not been able to build the `dist` zip and test that it looks as I intend it so I do not believe this is 100% ready. If you are open to these changes(or some version of them) I would love some help getting it built and testing it.
