### PR TITLE
New fallback to extract branch/commit on github

### DIFF
--- a/src/adapters/github.js
+++ b/src/adapters/github.js
@@ -155,6 +155,8 @@ class GitHub extends Adapter {
     const branch =
       // Code page
       $('.branch-select-menu .select-menu-item.selected').data('name') ||
+      // Page title
+      (document.title.match(/ at (\w+)/) || '')[1] ||
       // Pull requests page
       ($('.commit-ref.base-ref').attr('title') || ':').match(/:(.*)/)[1] ||
       // Reuse last selected branch if exist


### PR DESCRIPTION
#157 seems to be broken or not fixed. Here is my proposal.

Adds a new fallback to extract branch/commit from page title. Result:

<img width="984" alt="screen shot 2017-04-07 at 1 35 34 pm" src="https://cloud.githubusercontent.com/assets/3624712/24797098/6ffd2d1e-1b98-11e7-840c-ac8a64709bc0.png">

Examples of titles that match:

<pre>
  * buunguyen/octotree at 2b63178b6e5072bf358797d25913fdc6e0d51210
  * octotree/test at 2b63178b6e5072bf358797d25913fdc6e0d51210 · buunguyen/octotree
  * octotree/docs at master · buunguyen/octotree
</pre>

Examples of titles that do not match:

<pre>
  * buunguyen/octotree: Code tree for GitHub
  * Fixed typo. (#391) · buunguyen/octotree@8833647
</pre>
