### PR TITLE
Raise pr-tree response limit to max (300)

### DIFF
--- a/src/adapters/github.js
+++ b/src/adapters/github.js
@@ -180,7 +180,7 @@ class GitHub extends PjaxAdapter {
    */
    _getPatch(opts, cb) {
     const {pullNumber} = opts.repo
-    this._get(`/pulls/${pullNumber}/files`, opts, (err, res) => {
+    this._get(`/pulls/${pullNumber}/files?per_page=300`, opts, (err, res) => {
       if (err) cb(err)
       else {
         const diffMap = {}

--- a/src/styles/base.less
+++ b/src/styles/base.less
@@ -169,6 +169,11 @@
         height: 60px;
       }
     }
+    .octotree_opts_disclaimer {
+      color: gray;
+      display: block;
+      font-size: 12px;
+    }
   }
 }
 

--- a/src/template.html
+++ b/src/template.html
@@ -80,7 +80,11 @@
           </div>
 
           <div class="octotree_github_only">
-            <label><input type="checkbox" data-store="PR"> Show only changes in pull requests</label>
+            <label>
+              <input type="checkbox" data-store="PR">
+                Show only changes in pull requests
+              <span class="octotree_opts_disclaimer">Note: displays a maximum of 300 files</span>
+            </label>
           </div>
 
           <div>


### PR DESCRIPTION
### Description
The call made to get the files for a specific pull request defaults to only 30 per response. Larger PR's can have more than that many files.

### Proposal
The max that can be returned is 300 (per https://developer.github.com/v3/pulls/#list-pull-requests-files), so raised the limit to that.

