### PR TITLE
Fix issue with lazy loading and PR view

### DIFF
--- a/src/view.tree.js
+++ b/src/view.tree.js
@@ -23,7 +23,9 @@ class TreeView {
     $jstree.settings.core.data = (node, cb) => {
       const loadAll = this.adapter.canLoadEntireTree() &&
                       this.store.get(STORE.LOADALL)
-      node = !loadAll && (node.id === '#' ? {path: ''} : node.original)
+      // No lazy loading in PR tree view
+      const isPR = this.store.get(STORE.PR) && repo.pullNumber
+      node = !loadAll && !isPR && (node.id === '#' ? {path: ''} : node.original)
 
       this.adapter.loadCodeTree({repo, token, node}, (err, treeData) => {
         if (err) {
@@ -31,7 +33,7 @@ class TreeView {
         }
         else {
           treeData = this._sort(treeData)
-          if (loadAll) {
+          if (loadAll || isPR) {
             treeData = this._collapse(treeData)
           }
           cb(treeData)


### PR DESCRIPTION
### Description
This PR fixes issue https://github.com/buunguyen/octotree/issues/434, where the combination of lazy loading and pull request view was causing recursive trees to appear.

To reproduce the issue, navigate to any PR and change your settings to:
`Load entire tree at once: false`
`Show only pull request changes: true`


### Proposal
To fix, we add logic to check if we are in Pull Request mode to `view.tree.js`

Here is the tree in the repo linked to in https://github.com/buunguyen/octotree/issues/434 with the fix: 
<img width="342" alt="screen shot 2017-08-30 at 4 53 55 pm" src="https://user-images.githubusercontent.com/3138607/29900040-e5e58a76-8da3-11e7-9037-6e35b9ec0eb1.png">
