### PR TITLE
background: fix error while running permissions.remove

### DIFF
--- a/src/config/chrome/background.js
+++ b/src/config/chrome/background.js
@@ -61,7 +61,8 @@ chrome.runtime.onMessage.addListener((req, sender, sendRes) => {
 
       function removeUnnecessaryPermissions() {
         const whitelist = urls.concat([
-          'https://github.com/*'
+          'https://github.com/*',
+          'https://bitbucket.org/*'
         ])
         chrome.permissions.getAll((permissions) => {
           const toBeRemovedUrls = permissions.origins.filter((url) => {


### PR DESCRIPTION
### Description
bitbucket url should be added to whitelist because it is required permissions.
you can see the error in extension developer tools.

