### PR TITLE
Skip pjax loads if requested path is for different anchor on same page

### DIFF
--- a/src/adapters/pjax.js
+++ b/src/adapters/pjax.js
@@ -66,8 +66,8 @@ class PjaxAdapter extends Adapter {
     const $pjaxContainer = opts.$pjaxContainer
 
     // If we're on the same page but just navigating to a different anchor, don't bother fetching the page with pjax
-    const pathWithoutAnnchor = path.replace(/#.*$/, "")
-    const onSamePage = window.location.pathname == pathWithoutAnnchor
+    const pathWithoutAnchor = path.replace(/#.*$/, "")
+    const onSamePage = location.pathname == pathWithoutAnchor
 
     if ($pjaxContainer.length && !onSamePage) {
       $.pjax({

--- a/src/adapters/pjax.js
+++ b/src/adapters/pjax.js
@@ -65,7 +65,11 @@ class PjaxAdapter extends Adapter {
     opts = opts || {}
     const $pjaxContainer = opts.$pjaxContainer
 
-    if ($pjaxContainer.length) {
+    // If we're on the same page but just navigating to a different anchor, don't bother fetching the page with pjax
+    const pathWithoutAnnchor = path.replace(/#.*$/, "")
+    const onSamePage = window.location.pathname == pathWithoutAnnchor
+
+    if ($pjaxContainer.length && !onSamePage) {
       $.pjax({
         // needs full path for pjax to work with Firefox as per cross-domain-content setting
         url: location.protocol + '//' + location.host + path,


### PR DESCRIPTION
### Description
@buunguyen, when reviewing files on Github, each page click issues a pjax request for every file clicked on.  This seems unnecessary to me since all files are on the same page just with different anchors.  It would be better to just navigate to the requested anchor instead of refetching the page.

### Proposal
This modifies `pjax.selectFile` to skip the fetch if the request is for a different anchor on the same page that the user is already on
