### PR TITLE
Added Width to Header Repo Text - Fixed Button Header UI

### DIFF
--- a/src/adapters/github.less
+++ b/src/adapters/github.less
@@ -73,6 +73,7 @@
 
     .octotree_treeview {
       .octotree_header_repo {
+        width: 152px;
         font-size: 13px;
         font-weight: normal;
       }


### PR DESCRIPTION
### Description
Summary of what issue(s) this PR resolves

So this pull request solves a UI issue with the header repo and the button. The issue is mentioned here: https://github.com/buunguyen/octotree/issues/445

### Proposal
Summary of what changes this PR proposes

This pull request changes this: 
<img width="248" alt="capture d ecran 2017-11-04 a 19 31 08" src="https://user-images.githubusercontent.com/10472448/32411431-8bdeb7e6-c197-11e7-8074-465de4a4e1f8.png">

to this: 
<img width="271" alt="capture d ecran 2017-11-04 a 19 31 36" src="https://user-images.githubusercontent.com/10472448/32411434-9098a832-c197-11e7-88b6-f914d4784f87.png">

I understand that this pull request is similar to https://github.com/buunguyen/octotree/pull/446, but they haven't submitted a new pull request in awhile. 

So the solution proposed in the above pull request was to limit the width of the header repo. I limited it to 152px. 
