### PR TITLE
Fix file icons being in italic

### DIFF
--- a/src/styles/base.less
+++ b/src/styles/base.less
@@ -116,6 +116,7 @@
     }
     .jstree-default .jstree-icon, .jstree-default .jstree-icon:empty, .jstree-default .jstree-anchor {
       line-height: 24px !important;
+      font-style: normal;
     }
   }
 


### PR DESCRIPTION
### Description
Currently, the file icons are in italic.

### Proposal
This add the `font-style: normal` to the icons.