### PR TITLE
Easier token generation on Github

### DIFF
--- a/src/adapters/github.js
+++ b/src/adapters/github.js
@@ -58,7 +58,7 @@ class GitHub extends PjaxAdapter {
 
   // @override
   getCreateTokenUrl() {
-    return `${location.protocol}//${location.host}/settings/tokens/new?scopes=public_repo&description=OctoTree browser extension`
+    return `${location.protocol}//${location.host}/settings/tokens/new?scopes=repo&description=Octotree%20browser%20extension`
   }
 
   // @override

--- a/src/adapters/github.js
+++ b/src/adapters/github.js
@@ -58,7 +58,7 @@ class GitHub extends PjaxAdapter {
 
   // @override
   getCreateTokenUrl() {
-    return `${location.protocol}//${location.host}/settings/tokens/new`
+    return `${location.protocol}//${location.host}/settings/tokens/new?scopes=public_repo&description=OctoTree browser extension`
   }
 
   // @override


### PR DESCRIPTION
### Description
Inspired by other github-related extensions (notably OctoLinker browser extension and OctoLinker) this PR aims to automate even more token generation providing the minimal preset of permissions.

**Before:**
https://github.com/settings/tokens/new

**After:**
https://github.com/settings/tokens/new?scopes=public_repo&description=OctoTree%20browser%20extension