### PR TITLE
Get current user info from meta tag instead of body

### DIFF
--- a/src/adapters/bitbucket.js
+++ b/src/adapters/bitbucket.js
@@ -180,7 +180,7 @@ class Bitbucket extends PjaxAdapter {
         username =  result[0], token = result[1]
       }
       else {
-        const currentUser = JSON.parse($('body').attr('data-current-user'))
+        const currentUser = JSON.parse($('meta').attr('data-current-user'))
         if (!currentUser || !currentUser.username) {
           return cb({
             error: 'Error: Invalid token',


### PR DESCRIPTION
### Description
Fixes #508. Bitbucket changed how where they render the `data-current-user` attribute. It has been moved from the `body` tag to its own `meta` tag directly inside the `<head>`. 

Here is what it looks like now:

<img width="681" alt="screen shot 2018-04-28 at 9 47 28 am" src="https://user-images.githubusercontent.com/2854919/39397203-62ba8910-4ac9-11e8-977d-863c5c7c39c6.png">


### Proposal
Instead of selected the `data-current-user` from the `body`, grab it from the `meta` instead.

